### PR TITLE
Ajout de constructeurs dans PlageHoraire ,

### DIFF
--- a/src/main/java/com/JESIKOM/HowManager/models/PlageHoraire.java
+++ b/src/main/java/com/JESIKOM/HowManager/models/PlageHoraire.java
@@ -1,9 +1,12 @@
 package com.JESIKOM.HowManager.models;
 
 import jakarta.persistence.*;
+import lombok.AllArgsConstructor;
 import lombok.Data;
+import lombok.NoArgsConstructor;
 
-
+@NoArgsConstructor
+@AllArgsConstructor
 @Data
 @Entity
 @Table(name = "plage_horaire")
@@ -26,6 +29,23 @@ public class PlageHoraire {
     @Lob
     @Column(columnDefinition = "TEXT")
     private String notes;
+
+    public PlageHoraire(WeeklyTimeSlot plage, String poste, String lieu, String notes) {
+        this.plage = plage;
+        this.poste = poste;
+        this.lieu = lieu;
+        this.notes = notes;
+    }
+    public PlageHoraire(WeeklyTimeSlot plage, String poste) {
+        this.plage = plage;
+        this.poste = poste;
+    }
+    public PlageHoraire(WeeklyTimeSlot plage,String poste, String lieu) {
+        this.plage = plage;
+        this.poste = poste;
+        this.lieu = lieu;
+    }
+
 
 
 }

--- a/src/main/java/com/JESIKOM/HowManager/service/WeeklyTimeSlotService.java
+++ b/src/main/java/com/JESIKOM/HowManager/service/WeeklyTimeSlotService.java
@@ -65,7 +65,7 @@ public class WeeklyTimeSlotService {
     }
 
     public boolean isBefore(WeeklyTimeSlot slot, DayOfWeek day, LocalTime time) {
-        return (slot.getEndDay().compareTo(day) < 0) || (day == slot.getEndDay() && slot.getEndTime().isBefore(time));
+        return (slot.getEndDay().compareTo(day) < 0) || (day == slot.getEndDay() && (slot.getEndTime().isBefore(time)));
     }
 
     public boolean isAfter(WeeklyTimeSlot slot, DayOfWeek day, LocalTime time) {
@@ -76,8 +76,14 @@ public class WeeklyTimeSlotService {
         return !isBefore(slot, day, time) && !isAfter(slot, day, time);
     }
 
+    public boolean isFollowing( WeeklyTimeSlot slotFollower, WeeklyTimeSlot slotFollowed){
+        return  slotFollower.getStartDay().equals(slotFollowed.getEndDay()) &&
+                slotFollower.getStartTime().equals(slotFollowed.getEndTime());
+    }
+
     public boolean overlapsWith(WeeklyTimeSlot slot1, WeeklyTimeSlot slot2) {
-        return !(slot1.getEndDay().compareTo(slot2.getStartDay()) < 0 || slot1.getStartDay().compareTo(slot2.getEndDay()) > 0) &&
+        return  !(isFollowing(slot1,slot2)||isFollowing(slot2,slot1)) &&
+                !(slot1.getEndDay().compareTo(slot2.getStartDay()) < 0 || slot1.getStartDay().compareTo(slot2.getEndDay()) > 0) &&
                 !(slot1.getEndDay() == slot2.getStartDay() && slot1.getEndTime().isBefore(slot2.getStartTime())) &&
                 !(slot1.getStartDay() == slot2.getEndDay() && slot1.getStartTime().isAfter(slot2.getEndTime()));
     }

--- a/src/test/java/com/JESIKOM/HowManager/service/PlageHoraireServiceTest.java
+++ b/src/test/java/com/JESIKOM/HowManager/service/PlageHoraireServiceTest.java
@@ -1,10 +1,53 @@
 package com.JESIKOM.HowManager.service;
 
+import com.JESIKOM.HowManager.models.PlageHoraire;
+import com.JESIKOM.HowManager.models.WeeklyTimeSlot;
+import com.JESIKOM.HowManager.repository.PlageHoraireRepository;
+import com.JESIKOM.HowManager.repository.WeeklyTimeSlotRepository;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.beans.factory.annotation.Autowired;
+
+import java.time.DayOfWeek;
+import java.time.LocalTime;
 
 import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyFloat;
+import static org.mockito.Mockito.when;
 
+
+@ExtendWith(MockitoExtension.class)
 class PlageHoraireServiceTest {
+
+    @Mock
+    private WeeklyTimeSlotService wtsService;
+
+    @Mock
+    private PlageHoraireRepository repository;
+
+    @InjectMocks
+    private PlageHoraireService service;
+
+    PlageHoraire ph1 = new PlageHoraire(
+            new WeeklyTimeSlot(DayOfWeek.MONDAY, LocalTime.of(1,0),DayOfWeek.MONDAY,LocalTime.of(2,0)),
+            "Recep","maison","test");
+    PlageHoraire ph2 = new PlageHoraire(
+            new WeeklyTimeSlot(DayOfWeek.MONDAY,LocalTime.of(1,0),DayOfWeek.TUESDAY,LocalTime.of(0,30)),
+            "Recep","maison","test2");
+
+
+
+    @Test
+    void addPlageHoraireTest(){
+        //Cas valide
+        when(repository.save(ph1)).thenReturn(ph1);
+        assertSame(ph1,service.addPlageHoraire(ph1));
+
+    }
 
     @Test
     void updatePlageHoraireTest() {
@@ -13,9 +56,13 @@ class PlageHoraireServiceTest {
 
     @Test
     void computeDuree() {
+        when(wtsService.computeTime(any())).thenReturn(1.f);
+        assertEquals(1.f,service.computeDuree(ph1));
+        assertEquals(1.f,service.computeDuree(ph2));
+
     }
 
     @Test
-    void computeHeursMajorees() {
+    void computeHeuresMajorees() {
     }
 }

--- a/src/test/java/com/JESIKOM/HowManager/service/PlanningPatternServiceTest.java
+++ b/src/test/java/com/JESIKOM/HowManager/service/PlanningPatternServiceTest.java
@@ -1,20 +1,39 @@
 package com.JESIKOM.HowManager.service;
 
+import com.JESIKOM.HowManager.models.PlageHoraire;
+import com.JESIKOM.HowManager.models.WeeklyTimeSlot;
 import com.JESIKOM.HowManager.repository.PlanningPatternRepository;
 import org.junit.jupiter.api.Test;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
-import org.springframework.boot.test.mock.mockito.MockBean;
+
+
+import java.time.DayOfWeek;
+import java.time.LocalTime;
 
 import static org.junit.jupiter.api.Assertions.*;
 
 class PlanningPatternServiceTest {
 
     @Mock
-    PlanningPatternRepository planningPatternRepository;
+    PlanningPatternRepository repository;
+    @Mock
+    PlageHoraireService phService;
 
     @InjectMocks
-    PlanningPatternService planningPatternService;
+    PlanningPatternService service;
+    PlageHoraire ph1 = new PlageHoraire(
+             new WeeklyTimeSlot(DayOfWeek.TUESDAY, LocalTime.of(1, 0), DayOfWeek.TUESDAY, LocalTime.of(2, 0)),
+            "baba");
+    PlageHoraire phNoConflictHr = new PlageHoraire(
+            new WeeklyTimeSlot(DayOfWeek.TUESDAY, LocalTime.of(2, 0), DayOfWeek.TUESDAY, LocalTime.of(3, 0)),
+            "bobo");
+    PlageHoraire phNoConflictJ = new PlageHoraire(
+            new WeeklyTimeSlot(DayOfWeek.WEDNESDAY, LocalTime.of(0, 0), DayOfWeek.WEDNESDAY, LocalTime.of(3, 0)),
+            "bubu");
+    PlageHoraire phConflict = new PlageHoraire(
+                    new WeeklyTimeSlot(DayOfWeek.TUESDAY, LocalTime.of(1, 30), DayOfWeek.TUESDAY, LocalTime.of(3, 0)),
+                    "babu");
 
 
 
@@ -22,6 +41,7 @@ class PlanningPatternServiceTest {
 
     @Test
     void addPlanningPatternTest() {
+
 
 
     }

--- a/src/test/java/com/JESIKOM/HowManager/service/WeeklyTimeSlotServiceTest.java
+++ b/src/test/java/com/JESIKOM/HowManager/service/WeeklyTimeSlotServiceTest.java
@@ -25,6 +25,8 @@ class WeeklyTimeSlotServiceTest {
 
     private WeeklyTimeSlot currentTs;
     private final LocalTime beforeTime = LocalTime.of(0, 0);
+    private final LocalTime sameEndTime = LocalTime.of(2, 0);
+    private final LocalTime sameBeginTime = LocalTime.of(1, 0);
     private final LocalTime afterTime = LocalTime.of(3, 0);
     private final LocalTime withinTime = LocalTime.of(1, 30);
     private final DayOfWeek beforeDate = DayOfWeek.MONDAY;
@@ -40,7 +42,6 @@ class WeeklyTimeSlotServiceTest {
     void mergeTest() {
         WeeklyTimeSlot nextTs = new WeeklyTimeSlot(sameDate, beforeTime, afterDate, beforeTime.plusMinutes(30));
         WeeklyTimeSlot ts = weeklyTimeSlotService.merge(currentTs, nextTs);
-
         assertEquals(currentTs.getStartDay(), ts.getStartDay());
         assertEquals(nextTs.getEndDay(), ts.getEndDay());
         assertEquals(nextTs.getStartTime(), ts.getStartTime());
@@ -49,12 +50,15 @@ class WeeklyTimeSlotServiceTest {
 
     @Test
     void isBeforeTest() {
+        assertFalse(weeklyTimeSlotService.isBefore(currentTs,sameDate,sameBeginTime));
+        assertFalse(weeklyTimeSlotService.isBefore(currentTs,sameDate,sameEndTime));
         assertFalse(weeklyTimeSlotService.isBefore(currentTs, sameDate, beforeTime));
         assertFalse(weeklyTimeSlotService.isBefore(currentTs, sameDate, withinTime));
         assertFalse(weeklyTimeSlotService.isBefore(currentTs, beforeDate, afterTime));
         assertTrue(weeklyTimeSlotService.isBefore(currentTs, afterDate, beforeTime));
         assertTrue(weeklyTimeSlotService.isBefore(currentTs, sameDate, afterTime));
     }
+
 
     @Test
     void isAfterTest() {
@@ -75,6 +79,17 @@ class WeeklyTimeSlotServiceTest {
     }
 
     @Test
+    void isfollowingTest(){
+        WeeklyTimeSlot slotTrue = new WeeklyTimeSlot(sameDate, sameEndTime, sameDate, sameEndTime.plusMinutes(30));
+        WeeklyTimeSlot falseDay = new WeeklyTimeSlot(afterDate, sameEndTime, sameDate, sameEndTime.plusMinutes(30));
+        WeeklyTimeSlot falseTime1 = new WeeklyTimeSlot(sameDate,beforeTime,sameDate,sameEndTime);
+        assertTrue(weeklyTimeSlotService.isFollowing(slotTrue, currentTs));
+        assertFalse(weeklyTimeSlotService.isFollowing(falseDay, currentTs));
+        assertFalse(weeklyTimeSlotService.isFollowing(falseTime1, currentTs));
+        assertFalse(weeklyTimeSlotService.isFollowing(currentTs,currentTs));
+    }
+
+    @Test
     void overlapsWithTest() {
         WeeklyTimeSlot beforeAfter = new WeeklyTimeSlot(beforeDate, beforeTime, sameDate, afterTime);
         WeeklyTimeSlot beforeBefore = new WeeklyTimeSlot(beforeDate, afterTime, sameDate, beforeTime);
@@ -82,6 +97,8 @@ class WeeklyTimeSlotServiceTest {
         WeeklyTimeSlot beforeWithin = new WeeklyTimeSlot(beforeDate, beforeTime, sameDate, withinTime);
         WeeklyTimeSlot withinAfter = new WeeklyTimeSlot(sameDate, withinTime, sameDate, afterTime);
         WeeklyTimeSlot withinWithin = new WeeklyTimeSlot(sameDate, withinTime, sameDate, withinTime.plusMinutes(10));
+        WeeklyTimeSlot followingOne = new WeeklyTimeSlot(sameDate, sameEndTime, sameDate, afterTime);
+        WeeklyTimeSlot previousOne = new WeeklyTimeSlot(sameDate,beforeTime,sameDate, sameBeginTime);
 
         assertFalse(weeklyTimeSlotService.overlapsWith(currentTs, beforeBefore));
         assertFalse(weeklyTimeSlotService.overlapsWith(currentTs, afterAfter));
@@ -89,6 +106,10 @@ class WeeklyTimeSlotServiceTest {
         assertTrue(weeklyTimeSlotService.overlapsWith(currentTs, beforeWithin));
         assertTrue(weeklyTimeSlotService.overlapsWith(currentTs, withinAfter));
         assertTrue(weeklyTimeSlotService.overlapsWith(currentTs, withinWithin));
+
+        //Following TS
+        assertFalse(weeklyTimeSlotService.overlapsWith(currentTs, followingOne));
+        assertFalse(weeklyTimeSlotService.overlapsWith(currentTs, previousOne));
     }
 
     @Test


### PR DESCRIPTION
Modification de WTSlotService :
Deux slot qui se suivent ( 1h -2h et 2h-3H) ne se chevauchent pas